### PR TITLE
Remove whitespace linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - gochecknoglobals
     - unconvert
     - unparam
-    - whitespace
     - staticcheck
   settings:
     gocyclo:


### PR DESCRIPTION
## Summary
- remove `whitespace` from enabled linters in `.golangci.yml`

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ebfc7b710832f83d996f3bbebe9d7